### PR TITLE
Add ch-agent-zero entry point and update MCP configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,36 @@ You can set these variables in your environment or use a `.env` file.
 {
   "mcpServers": {
     "agent-zero": {
+      "command": "ch-agent-zero",
+      "env": {
+        "CLICKHOUSE_HOST": "your-clickhouse-host",
+        "CLICKHOUSE_PORT": "8443",
+        "CLICKHOUSE_USER": "your-username",
+        "CLICKHOUSE_PASSWORD": "your-password",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_VERIFY": "true",
+        "CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "300"
+      }
+    }
+  }
+}
+```
+
+For users who prefer using uv, the following configuration can also be used:
+
+```json
+{
+  "mcpServers": {
+    "agent-zero": {
       "command": "uv",
       "args": [
         "run",
         "--with",
-        "ch_agent_zero",
+        "ch-agent-zero",
         "--python",
         "3.13",
-        "ch_agent_zero"
+        "ch-agent-zero"
       ],
       "env": {
         "CLICKHOUSE_HOST": "your-clickhouse-host",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ Homepage = "https://github.com/maruthiprithivi/agent_zero"
 Documentation = "https://github.com/maruthiprithivi/agent_zero/blob/main/README.md"
 "Bug Tracker" = "https://github.com/maruthiprithivi/agent_zero/issues"
 
+[project.scripts]
+ch-agent-zero = "agent_zero.main:main"
+
 [tool.setuptools]
 packages = ["agent_zero", "agent_zero.monitoring"]
 package-dir = {"" = "."}


### PR DESCRIPTION
This commit:
1. Adds the 'ch-agent-zero' entry point in pyproject.toml to make the package executable as a command
2. Updates the README to show both direct command and uv configuration options
3. Fixes the issue where the MCP server couldn't find the ch-agent-zero command

🤖 Generated with [Claude Code](https://claude.ai/code)