### PR TITLE
fix: Resolve infinite recursion in MCP server run method - Replace re…

### DIFF
--- a/agent_zero/mcp_server.py
+++ b/agent_zero/mcp_server.py
@@ -1069,8 +1069,8 @@ def run(
         if auth_config:
             logger.info(f"Authentication enabled for user: {auth_config['username']}")
 
-    # Run using FastMCP's native run method
-    return mcp.run(host=host, port=port, **ssl_args)
+    # Run using the original run method to avoid recursion
+    return _original_run(host=host, port=port, **ssl_args)
 
 
 # Replace the original run method with our customized version


### PR DESCRIPTION
…cursive mcp.run() call with _original_run() to prevent maximum recursion depth exceeded error - Maintain existing configuration and authentication logic - Preserve original server startup behavior while fixing the recursion issue - This change prevents the server from getting stuck in an infinite loop during startup by calling the original run method instead of the overridden method.